### PR TITLE
Installation of osemosys2iamc later than v0.1

### DIFF
--- a/envs/iamc.yaml
+++ b/envs/iamc.yaml
@@ -8,4 +8,4 @@ dependencies:
 - pydantic < 2
 - pip
 - pip:
-  - osemosys2iamc==0.1
+  - osemosys2iamc>0.1


### PR DESCRIPTION
Changing back the requirement file for the iamc environment to install `osemosys2iamc` later than v0.1